### PR TITLE
Allow PHP >= 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     }
   ],
   "require": {
-    "php": "^7.4",
+    "php": ">=7.4",
     "guzzlehttp/guzzle": "~6.0"
   },
   "autoload": {


### PR DESCRIPTION
Changing PHP version requirement from ^7.4 (>=7.4 < 8.0) for >=7.4 as it is what the README states (PHP 7.4 or higher)

See [Composer documentation on Caret Version Range](https://getcomposer.org/doc/articles/versions.md#caret-version-range-)